### PR TITLE
update to 1.1.2

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "python-lsp-jsonrpc" %}
-{% set version = "1.0.0" %}
+{% set version = "1.1.2" %}
 
 package:
   name: {{ name|lower }}
@@ -7,19 +7,22 @@ package:
 
 source:
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
-  sha256: 7bec170733db628d3506ea3a5288ff76aa33c70215ed223abdb0d95e957660bd
+  sha256: 4688e453eef55cd952bff762c705cedefa12055c0aec17a06f595bcc002cc912
 
 build:
   noarch: python
   number: 0
-  script: {{ PYTHON }} -m pip install . --no-deps --ignore-installed --no-cache-dir -vvv
+  script: {{ PYTHON }} -m pip install . --no-deps --no-build-isolation -vv
 
 requirements:
   host:
-    - python >=3.6
+    - python >=3.8
+    - setuptools >=61.2.0
+    - setuptools-scm >=3.4.3
     - pip
+    - wheel
   run:
-    - python >=3.6
+    - python >=3.8
     - ujson >=3.0.0
 
 test:
@@ -36,8 +39,9 @@ about:
   license: MIT
   license_file: LICENSE
   license_family: MIT
-  summary: A Python 3.6+ server implementation of the JSON RPC 2.0 protocol.
+  summary: A Python server implementation of the JSON RPC 2.0 protocol.
   dev_url: https://github.com/python-lsp/python-lsp-jsonrpc
+  doc_url: https://github.com/python-lsp/python-lsp-jsonrpc
 
 extra:
   recipe-maintainers:


### PR DESCRIPTION
Changes:
- update to 1.1.2
- chose to leave it as noarch

https://github.com/python-lsp/python-lsp-jsonrpc/blob/v1.1.2/pyproject.toml